### PR TITLE
switch S3 reads to anonymous access (no credentials needed)

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -91,7 +91,7 @@ ca_county_geoids <- readRDS(here::here("data", "ca_counties.rds"))$GEOID
 # Forest type and structure class lookup — loaded from S3 (~3KB).
 # Used as global fallback for filter checkboxes; the actual choices are
 # narrowed to AOI-specific values when freq_table is available.
-all_vars_codes <- aws.s3::s3readRDS(bucket = S3_BUCKET, object = S3_ALL_VARS)
+all_vars_codes <- s3_read_rds(S3_ALL_VARS)
 
 forest_types <- all_vars_codes |>
   dplyr::filter(variable == "ForTyp") |>
@@ -819,7 +819,7 @@ server <- function(input, output, session) {
           variant <- ifelse(variant_pct >= 0.5, "CA", "CR")
 
           # Fetch per-county TreeMap ID files from S3
-          bucket_contents <- aws.s3::get_bucket(bucket = S3_BUCKET, prefix = S3_TMIDS_PREFIX)
+          bucket_contents <- s3_list_bucket(S3_TMIDS_PREFIX)
           files <- sapply(bucket_contents, function(x) x$Key)
           # Extract GEOID from filenames (pattern: CountyName_GEOID_tmids_only.rds)
           file_geoids <- sapply(files, function(f) {
@@ -831,7 +831,7 @@ server <- function(input, output, session) {
           # Read and combine TreeMap IDs across all matched county files
           tm_out <- NULL
           for (f in matched_files) {
-            chunk <- aws.s3::s3readRDS(bucket = S3_BUCKET, object = f)
+            chunk <- s3_read_rds(f)
             colnames(chunk) <- c("lat", "lon", "tm_id")
             chunk <- chunk |>
               dplyr::filter(!is.na(tm_id)) |>

--- a/R/ec_labels.R
+++ b/R/ec_labels.R
@@ -86,3 +86,28 @@ S3_ALL_VARS       <- s3_path("rshiny-spatial-data", "all_vars_codes.rds")
 S3_UNIQUE_STANDS  <- s3_path("rshiny-spatial-data", "unique_stands_western.rds")
 S3_COUNTIES_GPKG  <- s3_path("rshiny-spatial-data", "tl_2024_western_counties.gpkg")
 S3_TMIDS_PREFIX   <- s3_path("rshiny-spatial-data", "filtered_tmids_by_county")
+
+# ── Anonymous S3 readers ─────────────────────────────────────────────────
+# vp-open-science is a public bucket. Passing empty key/secret tells aws.s3
+# to skip request signing, so co-authors don't need AWS credentials.
+S3_REGION <- "us-west-2"
+
+s3_read_rds <- function(object) {
+  aws.s3::s3readRDS(
+    object = object,
+    bucket = S3_BUCKET,
+    region = S3_REGION,
+    key    = "",
+    secret = ""
+  )
+}
+
+s3_list_bucket <- function(prefix) {
+  aws.s3::get_bucket(
+    bucket = S3_BUCKET,
+    prefix = prefix,
+    region = S3_REGION,
+    key    = "",
+    secret = ""
+  )
+}

--- a/R/functions.R
+++ b/R/functions.R
@@ -40,10 +40,7 @@ get_tm_ids <- function(aoi_path, filetype, unique_ids){
   
   
   # Fetch TM IDs from the S3 bucket
-  county_tmids <- aws.s3::get_bucket(
-    bucket = S3_BUCKET,
-    prefix = S3_TMIDS_PREFIX
-  )
+  county_tmids <- s3_list_bucket(S3_TMIDS_PREFIX)
   
   # Parse file paths from the bucket
   files <- county_tmids %>%
@@ -66,10 +63,7 @@ get_tm_ids <- function(aoi_path, filetype, unique_ids){
   # Process each filtered filename
   tm_out <- NULL
   for (i in seq_along(counts)) {
-    tm_ids <- aws.s3::s3readRDS(
-      bucket = S3_BUCKET,
-      object = counts[i]
-    )
+    tm_ids <- s3_read_rds(counts[i])
     
     # Filter TM IDs within AOI bounds
     dims <- sf::st_bbox(aoi)
@@ -129,7 +123,7 @@ get_tm_ids <- function(aoi_path, filetype, unique_ids){
 #' @export
 load_stand_data <- function(variant) {
   s3_object <- if (variant == "CA") S3_CA_STANDLEVEL else S3_CR_STANDLEVEL
-  aws.s3::s3readRDS(bucket = S3_BUCKET, object = s3_object)
+  s3_read_rds(s3_object)
 }
 
 #' Load StdStk (Species) Data from S3
@@ -141,7 +135,7 @@ load_stand_data <- function(variant) {
 #' @export
 load_stdstk_data <- function(variant) {
   s3_object <- if (variant == "CA") S3_CA_STDSTK else S3_CR_STDSTK
-  aws.s3::s3readRDS(bucket = S3_BUCKET, object = s3_object)
+  s3_read_rds(s3_object)
 }
 
 


### PR DESCRIPTION
Add s3_read_rds() and s3_list_bucket() helpers to ec_labels.R that pass empty key/secret to aws.s3, skipping request signing. The vp-open-science bucket is public, so co-authors don't need AWS credentials to run the app.

Replace all direct aws.s3:: calls in app.R (3 sites) and functions.R (4 sites) with the new helpers. Tested with AWS_ACCESS_KEY_ID="" and AWS_SECRET_ACCESS_KEY="" — app starts and reads data correctly.